### PR TITLE
docs: add MCP Server documentation

### DIFF
--- a/docs/mcp/_category_.json
+++ b/docs/mcp/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "MCP Server",
+  "position": 5,
+  "link": {
+    "type": "doc",
+    "id": "mcp/index"
+  }
+}

--- a/docs/mcp/examples.md
+++ b/docs/mcp/examples.md
@@ -1,0 +1,128 @@
+---
+title: Example Prompts
+sidebar_position: 4
+---
+
+# Example Prompts
+
+Here are example prompts you can use with Claude once connected to Mipler via MCP.
+
+## Analyzing Data
+
+```
+Show me my top 10 selling products this month
+```
+
+```
+What's my average order value by country?
+```
+
+```
+Analyze customer purchase patterns over the last 90 days
+```
+
+```
+Which products have the highest return rate?
+```
+
+```
+Compare sales performance: this week vs last week
+```
+
+```
+What are my best-selling product categories?
+```
+
+## Building Reports
+
+```
+Create a report showing daily sales for the last 30 days
+```
+
+```
+Build a report comparing this month vs last month sales by product
+```
+
+```
+Make a customer cohort analysis report
+```
+
+```
+Create a report with orders grouped by fulfillment status
+```
+
+```
+Build a report showing revenue by marketing channel
+```
+
+## Creating Dashboards
+
+```
+Create a dashboard for daily sales performance with key metrics
+```
+
+```
+Build an inventory monitoring dashboard
+```
+
+```
+Make a customer overview dashboard with total customers, new customers this month, and top customers
+```
+
+## Working with Data Model
+
+```
+Show me what tables and columns are available in my data model
+```
+
+```
+Add a computed column for profit margin to the orders table
+```
+
+```
+What explores are available for building reports?
+```
+
+```
+Show me the structure of the orders table
+```
+
+## Running Expressions
+
+```
+Calculate total revenue for the last 7 days using ACE
+```
+
+```
+Validate this expression: orders | summarize(sum(total))
+```
+
+## Tips for Better Results
+
+### Be Specific
+Instead of:
+> "Show me sales"
+
+Try:
+> "Show me daily sales for the last 30 days, grouped by product category"
+
+### Provide Context
+Instead of:
+> "Create a report"
+
+Try:
+> "Create a report showing top 20 customers by total order value in the last 90 days"
+
+### Use Filters
+Instead of:
+> "List all orders"
+
+Try:
+> "List orders from the last week with status 'fulfilled' and total over $100"
+
+### Ask for Specific Metrics
+Instead of:
+> "How are sales?"
+
+Try:
+> "What was my total revenue, order count, and average order value last month compared to the previous month?"

--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -1,0 +1,39 @@
+---
+title: MCP Server
+sidebar_position: 1
+---
+
+# MCP Server Overview
+
+The Model Context Protocol (MCP) is an open standard developed by Anthropic that allows AI applications like Claude to securely connect to external data sources. With Mipler MCP Server, you can connect Claude directly to your Shopify store data and perform analytics, build reports, and get business insights through natural conversation.
+
+## What You Can Do with MCP
+
+- **Analyze Data** — Ask questions about your Shopify store in natural language
+- **Build Reports** — Create custom reports through conversation
+- **Create Dashboards** — Design dashboards by describing what you need
+- **Modify Data Model** — Add computed columns and customize your schema
+- **Run Expressions** — Execute ACE expressions for custom calculations
+
+## Supported Clients
+
+Mipler MCP Server works with any MCP-compatible client:
+
+| Client | Platform | Description |
+|--------|----------|-------------|
+| Claude Desktop | macOS, Windows | Anthropic's official desktop application |
+| Claude Web | Browser | Use Claude at claude.ai |
+| Claude Code | CLI | Command-line interface for developers |
+
+## Getting Started
+
+1. [Get your MCP Connection URL](./setup#get-mcp-url) from Mipler Settings
+2. [Configure your client](./setup#configuration) (Claude Desktop, Web, or Code)
+3. [Start using MCP tools](./tools) to work with your data
+
+## Security
+
+- Your MCP Connection URL contains a unique access key — keep it private
+- All connections are encrypted via HTTPS
+- Claude accesses data through Mipler's secure API
+- Your Shopify credentials are never shared directly with Claude

--- a/docs/mcp/setup.md
+++ b/docs/mcp/setup.md
@@ -1,0 +1,147 @@
+---
+title: Setup & Configuration
+sidebar_position: 2
+---
+
+# MCP Setup & Configuration
+
+This guide explains how to connect Mipler MCP Server to Claude Desktop, Claude Web, and Claude Code.
+
+## Get Your MCP Connection URL {#get-mcp-url}
+
+First, get your unique MCP Connection URL from Mipler:
+
+1. Log in to your Mipler account at [app.mipler.com](https://app.mipler.com)
+2. Go to **Settings** in the left sidebar
+3. Find the **MCP Connection** section
+4. Copy the URL (format: `https://app.mipler.com/mcp/your-key...`)
+
+:::warning Keep Your URL Private
+Your MCP Connection URL contains your unique access key that grants access to your Shopify data. Never share it publicly.
+:::
+
+## Configuration {#configuration}
+
+:::info Claude Web Max Plan Required
+Native MCP integration (adding connectors directly) is only available in **Claude Web Max plan**. For Claude Desktop and Claude Code, use the `mcp-remote` method described below.
+:::
+
+### Claude Desktop
+
+1. **Open Claude Desktop** on your computer
+
+2. **Go to Settings**
+   - Click **Claude** in the menu bar (top of screen)
+   - Select **Settings**
+   - Click **Developer** tab
+
+3. **Edit Config File**
+   - Click **Edit Config** button
+   - This opens `claude_desktop_config.json`
+
+4. **Add This Code**
+   ```json
+   {
+     "mcpServers": {
+       "Mipler": {
+         "command": "npx",
+         "args": [
+           "mcp-remote@latest",
+           "https://app.mipler.com/mcp/YOUR-MCP-URL-HERE"
+         ]
+       }
+     }
+   }
+   ```
+
+5. **Save & Restart**
+   - Save the file
+   - Quit Claude Desktop completely
+   - Reopen Claude Desktop
+
+6. **Verify**
+   - Look for MCP icon (🔨) in chat input box
+   - Check Settings → Developer to see server status
+
+### Claude Web (claude.ai) — Max Plan Only
+
+Native MCP integration is available only for **Max plan** subscribers.
+
+1. Go to [claude.ai](https://claude.ai) and log in
+2. Click on your profile icon in the bottom left corner
+3. Select **Settings**
+4. Go to the **Integrations** tab
+5. Click **Add Integration**
+6. Paste your MCP Connection URL
+7. Click **Connect**
+
+Once connected, you can configure permissions for each tool:
+
+| Permission | Description |
+|------------|-------------|
+| **Auto-approve** | Claude can use the tool without asking |
+| **Needs approval** | Claude will ask before using the tool |
+| **Disabled** | Claude cannot use this tool |
+
+:::tip Recommended Permissions
+Set read-only tools (`report_list`, `dashboard_list`, `datamodel_summary`) to **Auto-approve** and write operations (`report_create`, `dashboard_delete`) to **Needs approval** for safety.
+:::
+
+### Claude Code (CLI)
+
+Add the MCP server using the command line:
+
+```bash
+claude mcp add Mipler -- npx mcp-remote@latest https://app.mipler.com/mcp/YOUR-MCP-URL-HERE
+```
+
+Or manually edit `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "Mipler": {
+      "command": "npx",
+      "args": [
+        "mcp-remote@latest",
+        "https://app.mipler.com/mcp/YOUR-MCP-URL-HERE"
+      ]
+    }
+  }
+}
+```
+
+Then restart Claude Code.
+
+## Verify Connection
+
+After configuration, verify the connection by asking Claude:
+
+> "List my Mipler reports"
+
+or
+
+> "Show me available dashboards"
+
+If configured correctly, Claude will use the MCP tools to fetch and display your data.
+
+## Troubleshooting
+
+### Connection Issues
+
+- Verify your MCP URL is correct and complete
+- Make sure you have an active Mipler subscription
+- Check that your Shopify store is properly connected to Mipler
+- Restart Claude Desktop/Code after changing configuration
+
+### Tools Not Appearing
+
+- Refresh the integration in Claude Web settings
+- Verify the configuration JSON syntax is correct
+- Check for any error messages in Claude Desktop console
+
+### Permission Errors
+
+- Ensure your Mipler account has the necessary permissions
+- Check that the tool isn't disabled in Claude Web settings
+- Try regenerating your MCP URL in Mipler Settings

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -1,0 +1,272 @@
+---
+title: Available Tools
+sidebar_position: 3
+---
+
+# MCP Tools Reference
+
+Once connected, Claude has access to the following tools for working with your Shopify data.
+
+## Report Tools
+
+| Tool | Description | Type |
+|------|-------------|------|
+| `report_list` | List all available reports. Optionally filter by group name. | Read |
+| `report_get` | Get the full details of a specific report by its ID. Returns complete report configuration. | Read |
+| `report_run` | Run a report and return the query results as JSON. | Read |
+| `report_create` | Create a new report with specified configuration. | Write |
+| `report_update` | Update an existing report configuration. | Write |
+| `report_delete` | Permanently delete a report. This action cannot be undone. | Delete |
+
+### report_list
+
+List all available reports with optional filtering.
+
+**Parameters:**
+- `group` (optional): Filter reports by group name
+
+**Returns:** List of reports with ID, title, group, and description.
+
+### report_get
+
+Get complete report configuration.
+
+**Parameters:**
+- `report_id` (required): The UUID of the report
+
+**Returns:** Full report configuration including query, visualization settings, and metadata as JSON.
+
+### report_run
+
+Execute a report and get results.
+
+**Parameters:**
+- `report_id` (required): The UUID of the report to run
+
+**Returns:** Query results as JSON with columns and rows.
+
+### report_create
+
+Create a new report.
+
+**Parameters:**
+- `report_json` (required): Report configuration as JSON string (TsReport structure with title, query, explore, and fields)
+
+**Returns:** Created report ID and title.
+
+### report_update
+
+Update an existing report.
+
+**Parameters:**
+- `report_json` (required): Report configuration as JSON string including the `id` field
+
+**Returns:** Updated report ID and title.
+
+### report_delete
+
+Permanently delete a report.
+
+**Parameters:**
+- `report_id` (required): The UUID of the report to delete
+
+**Returns:** Confirmation message.
+
+---
+
+## Dashboard Tools
+
+| Tool | Description | Type |
+|------|-------------|------|
+| `dashboard_list` | List all available dashboards with ID, title, description, and block count. | Read |
+| `dashboard_get` | Get the full details of a specific dashboard including blocks, filters, and metadata. | Read |
+| `dashboard_create` | Create a new dashboard with specified blocks and configuration. | Write |
+| `dashboard_update` | Update an existing dashboard configuration. | Write |
+| `dashboard_delete` | Permanently delete a dashboard. This action cannot be undone. | Delete |
+
+### dashboard_list
+
+List all dashboards.
+
+**Parameters:** None
+
+**Returns:** List of dashboards with ID, title, description, and block count.
+
+### dashboard_get
+
+Get complete dashboard configuration.
+
+**Parameters:**
+- `dashboard_id` (required): The UUID of the dashboard
+
+**Returns:** Full dashboard configuration including blocks, filters, and metadata as JSON.
+
+### dashboard_create
+
+Create a new dashboard.
+
+**Parameters:**
+- `dashboard_json` (required): Dashboard configuration as JSON string (TsDashboard structure with title, blocks, and filters)
+
+**Returns:** Created dashboard ID and title.
+
+### dashboard_update
+
+Update an existing dashboard.
+
+**Parameters:**
+- `dashboard_json` (required): Dashboard configuration as JSON string including the `id` field
+
+**Returns:** Updated dashboard ID and title.
+
+### dashboard_delete
+
+Permanently delete a dashboard.
+
+**Parameters:**
+- `dashboard_id` (required): The UUID of the dashboard to delete
+
+**Returns:** Confirmation message.
+
+---
+
+## Data Model Tools
+
+| Tool | Description | Type |
+|------|-------------|------|
+| `datamodel_summary` | Get a compact summary of the schema with all table and column names. | Read |
+| `datamodel_get` | Get the full datamodel schema or a specific entity by path. | Read |
+| `datamodel_patch` | Apply batch changes to the datamodel schema using JSON Patch operations. | Write |
+
+### datamodel_summary
+
+Get a compact overview of available tables and columns.
+
+**Parameters:** None
+
+**Returns:** Object with:
+- `explores`: List of explore names
+- `tables`: Map of table names to their labels and column names
+
+Use this to discover available fields for building queries.
+
+### datamodel_get
+
+Get full schema or specific entity.
+
+**Parameters:**
+- `path` (optional): Name-based path to get specific entity
+
+**Path Examples:**
+- `/tables[name=orders]` — get single table
+- `/tables[name=orders]/columns[name=total]` — get single column
+- `/tables[name=orders]/datasource` — get datasource config
+- `/explores[name=sales]` — get single explore
+- `/explores[name=sales]/relationships[to=customers.id]` — get single relationship
+- `/crossRelationships[to=refunds.order_id]` — get cross relationship
+
+**Returns:** Full schema (no path) or specific entity as JSON.
+
+### datamodel_patch
+
+Apply batch changes to the schema.
+
+**Parameters:**
+- `operations` (required): Array of patch operations
+
+**Operations:**
+- `add` — add new entity
+- `replace` — update existing value
+- `remove` — delete entity
+
+**Path Syntax:**
+- `/tables[name=orders]/columns[name=total]/label` — target a column field
+- `/tables[name=orders]/columns/-` — append new column (- means append)
+- `/explores[name=sales]/relationships[to=customers]` — target a relationship
+
+**Examples:**
+
+Add a column:
+```json
+{
+  "op": "add",
+  "path": "/tables[name=orders]/columns/-",
+  "value": {
+    "name": "discount",
+    "kind": "measure",
+    "dataType": "float"
+  }
+}
+```
+
+Update a label:
+```json
+{
+  "op": "replace",
+  "path": "/tables[name=orders]/columns[name=total]/label",
+  "value": "Order Total"
+}
+```
+
+Delete a column:
+```json
+{
+  "op": "remove",
+  "path": "/tables[name=orders]/columns[name=old_field]"
+}
+```
+
+---
+
+## ACE Expression Tools
+
+| Tool | Description | Type |
+|------|-------------|------|
+| `ace_validate` | Validate an ACE expression. Returns whether the expression is valid and any error message. | Read |
+| `ace_run` | Run/execute an ACE expression and return the result. | Read |
+
+### ace_validate
+
+Check if an ACE expression is valid.
+
+**Parameters:**
+- `expression` (required): The ACE expression to validate
+
+**Returns:**
+- `valid`: boolean
+- `error`: error message (if invalid)
+
+### ace_run
+
+Execute an ACE expression.
+
+**Parameters:**
+- `expression` (required): The ACE expression to execute
+
+**Returns:** Query results as JSON.
+
+---
+
+## Tool Categories Summary
+
+### Read-Only Tools (Safe)
+These tools only read data and don't modify anything:
+- `report_list`, `report_get`, `report_run`
+- `dashboard_list`, `dashboard_get`
+- `datamodel_summary`, `datamodel_get`
+- `ace_validate`, `ace_run`
+
+### Write Tools (Require Caution)
+These tools create or modify data:
+- `report_create`, `report_update`
+- `dashboard_create`, `dashboard_update`
+- `datamodel_patch`
+
+### Delete Tools (Destructive)
+These tools permanently delete data:
+- `report_delete`
+- `dashboard_delete`
+
+:::tip Permission Recommendations
+In Claude Web, set read-only tools to **Auto-approve** and write/delete tools to **Needs approval** for a safe yet productive workflow.
+:::


### PR DESCRIPTION
Add comprehensive documentation for MCP Server integration:
- Overview and introduction (index.md)
- Setup guide for Claude Desktop, Web, and Code (setup.md)
  - Note about Max plan requirement for Claude Web
  - mcp-remote instructions for Desktop and Code
- Complete tools reference with all parameters (tools.md)
- Example prompts for common use cases (examples.md)